### PR TITLE
Added point cloud streaming to Kinect 2 Client

### DIFF
--- a/Kinect2Server/App.config
+++ b/Kinect2Server/App.config
@@ -25,6 +25,9 @@
             <setting name="AudioPort" serializeAs="String">
                 <value>9004</value>
             </setting>
+          <setting name="PointCloudPort" serializeAs="String">
+            <value>9005</value>
+          </setting>
         </PersonalRobotics.Kinect2Server.Properties.Settings>
     </applicationSettings>
 </configuration>

--- a/Kinect2Server/Properties/Settings.Designer.cs
+++ b/Kinect2Server/Properties/Settings.Designer.cs
@@ -67,5 +67,16 @@ namespace PersonalRobotics.Kinect2Server.Properties {
                 return ((short)(this["AudioPort"]));
             }
         }
+
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("9005")]
+        public short PointCloudPort
+        {
+            get
+            {
+                return ((short)(this["PointCloudPort"]));
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello there! Back over here in the Sigproc lab in Cambridge @rjw57 and myself have been making extensive use of the k2_server/client packages for pulling data from the Kinect 2. For some reconstruction tasks we found it useful to convert the DepthFrame data into point clouds on the server machine, and streaming the point cloud over the network directly. 

We have made some modifications to the Kinect2ServerService frame recieved callback function to convert a depth image frame to a point cloud and broadcast it as a byte array over a new port, which is defined in the app.config. The commit should be viewed in parallel with changes to the K2 client package (soon to come), which adds a new node allowing the client to recieve and deserialise point cloud data.
